### PR TITLE
Bugfix: Run() fails for queries, add MarshalJSON()

### DIFF
--- a/aggregations.go
+++ b/aggregations.go
@@ -40,6 +40,10 @@ func (req *AggregationRequest) Map() map[string]interface{} {
 	}
 }
 
+func (req *AggregationRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.Map())
+}
+
 func (req *AggregationRequest) Run(
 	api *elasticsearch.Client,
 	o ...func(*esapi.SearchRequest),

--- a/es_test.go
+++ b/es_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/jgroeneveld/trial/assert"
 )
 
 type mapTest struct {
@@ -37,4 +39,21 @@ func sameJSON(a, b map[string]interface{}) (aJSON, bJSON []byte, ok bool) {
 
 	ok = reflect.DeepEqual(aJSON, bJSON)
 	return aJSON, bJSON, ok
+}
+
+type jsonTest struct {
+	name    string
+	q       json.Marshaler
+	expJSON string
+	expErr  error
+}
+
+func runJSONTests(t *testing.T, tests []jsonTest) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := test.q.MarshalJSON()
+			assert.Equal(t, test.expErr, err)
+			assert.Equal(t, test.expJSON, string(b))
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,6 @@ go 1.13
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.6.0
 	github.com/fatih/structs v1.1.0
+	github.com/jgroeneveld/schema v1.0.0 // indirect
+	github.com/jgroeneveld/trial v2.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,7 @@ github.com/elastic/go-elasticsearch/v8 v8.0.0-20200210103600-aff00e5adfde h1:Y9S
 github.com/elastic/go-elasticsearch/v8 v8.0.0-20200210103600-aff00e5adfde/go.mod h1:xe9a/L2aeOgFKKgrO3ibQTnMdpAeL0GC+5/HpGScSa4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/jgroeneveld/schema v1.0.0 h1:J0E10CrOkiSEsw6dfb1IfrDJD14pf6QLVJ3tRPl/syI=
+github.com/jgroeneveld/schema v1.0.0/go.mod h1:M14lv7sNMtGvo3ops1MwslaSYgDYxrSmbzWIQ0Mr5rs=
+github.com/jgroeneveld/trial v2.0.0+incompatible h1:d59ctdgor+VqdZCAiUfVN8K13s0ALDioG5DWwZNtRuQ=
+github.com/jgroeneveld/trial v2.0.0+incompatible/go.mod h1:I6INLW96EN8WysNBXUFI3M4RIC8ePg9ntAc/Wy+U/+M=

--- a/queries.go
+++ b/queries.go
@@ -22,12 +22,16 @@ func (req *QueryRequest) Map() map[string]interface{} {
 	}
 }
 
+func (req *QueryRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(req.Map())
+}
+
 func (req *QueryRequest) Run(
 	api *elasticsearch.Client,
 	o ...func(*esapi.SearchRequest),
 ) (res *esapi.Response, err error) {
 	var b bytes.Buffer
-	err = json.NewEncoder(&b).Encode(req.Query.Map())
+	err = json.NewEncoder(&b).Encode(req.Map())
 	if err != nil {
 		return nil, err
 	}

--- a/queries_test.go
+++ b/queries_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestQueries(t *testing.T) {
+func TestQueryMaps(t *testing.T) {
 	runMapTests(t, []mapTest{
 		{
 			"a simple match_all query",
@@ -63,6 +63,20 @@ func TestQueries(t *testing.T) {
 					},
 				},
 			},
+		},
+	})
+}
+
+func TestQueryJSONs(t *testing.T) {
+	runJSONTests(t, []jsonTest{
+		{
+			"simple query",
+			Query(
+				Bool().
+					Must(Term("account_id", "bla")),
+			),
+			`{"query":{"bool":{"must":[{"term":{"account_id":{"value":"bla"}}}]}}}`,
+			nil,
 		},
 	})
 }


### PR DESCRIPTION
The `Run()` method on the `QueryRequest` type would fail, since it would
encode the _inner_ body of the query to JSON and not the complete, outer
body (i.e. including the "body: {}" portion).

The commit also adds `MarshalJSON()` methods to both `QueryRequest` and
`AggregationRequest`, allowing them to implement the `json.Marshaller`
interface, and providing easier debugging of the library. A test
skeleton for this is also added.