### PR TITLE
Support _source, sort and post_filter in search requests

### DIFF
--- a/common.go
+++ b/common.go
@@ -4,13 +4,19 @@ package esquery
 // queries. Currently, only the "includes" option is supported.
 type Source struct {
 	includes []string
+	excludes []string
 }
 
 // Map returns a map representation of the Source object.
 func (source Source) Map() map[string]interface{} {
-	return map[string]interface{}{
-		"includes": source.includes,
+	m := make(map[string]interface{})
+	if len(source.includes) > 0 {
+		m["includes"] = source.includes
 	}
+	if len(source.excludes) > 0 {
+		m["excludes"] = source.excludes
+	}
+	return m
 }
 
 // Sort represents a list of keys to sort by.

--- a/search.go
+++ b/search.go
@@ -15,12 +15,13 @@ import (
 // Not all features of the search API are currently supported, but a request can
 // currently include a query, aggregations, and more.
 type SearchRequest struct {
-	query   Mappable
-	aggs    []Aggregation
-	from    *uint64
-	size    *uint64
-	explain *bool
-	timeout *time.Duration
+	query      Mappable
+	aggs       []Aggregation
+	postFilter Mappable
+	from       *uint64
+	size       *uint64
+	explain    *bool
+	timeout    *time.Duration
 }
 
 // Search creates a new SearchRequest object, to be filled via method chaining.
@@ -37,6 +38,12 @@ func (req *SearchRequest) Query(q Mappable) *SearchRequest {
 // Aggs sets one or more aggregations for the request.
 func (req *SearchRequest) Aggs(aggs ...Aggregation) *SearchRequest {
 	req.aggs = aggs
+	return req
+}
+
+// PostFilter sets a post_filter for the request.
+func (req *SearchRequest) PostFilter(filter Mappable) *SearchRequest {
+	req.postFilter = filter
 	return req
 }
 
@@ -80,6 +87,9 @@ func (req *SearchRequest) Map() map[string]interface{} {
 		}
 
 		m["aggs"] = aggs
+	}
+	if req.postFilter != nil {
+		m["post_filter"] = req.postFilter.Map()
 	}
 	if req.size != nil {
 		m["size"] = *req.size

--- a/search_test.go
+++ b/search_test.go
@@ -46,6 +46,10 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
+				Sort("field_1", OrderDesc).
+				Sort("field_2", OrderAsc).
+				SourceIncludes("field_1", "field_2").
+				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)),
 			map[string]interface{}{
 				"query": map[string]interface{}{
@@ -99,6 +103,14 @@ func TestSearchMaps(t *testing.T) {
 				"from":    5,
 				"explain": true,
 				"timeout": "20s",
+				"sort": []map[string]interface{}{
+					{"field_1": map[string]interface{}{"order": "desc"}},
+					{"field_2": map[string]interface{}{"order": "asc"}},
+				},
+				"_source": map[string]interface{}{
+					"includes": []string{"field_1", "field_2"},
+					"excludes": []string{"field_3"},
+				},
 			},
 		},
 	})

--- a/search_test.go
+++ b/search_test.go
@@ -42,6 +42,7 @@ func TestSearchMaps(t *testing.T) {
 					StringStats("tag_stats", "tags").
 						ShowDistribution(true),
 				).
+				PostFilter(Range("score").Gt(0)).
 				Size(30).
 				From(5).
 				Explain(true).
@@ -84,6 +85,13 @@ func TestSearchMaps(t *testing.T) {
 						"string_stats": map[string]interface{}{
 							"field":             "tags",
 							"show_distribution": true,
+						},
+					},
+				},
+				"post_filter": map[string]interface{}{
+					"range": map[string]interface{}{
+						"score": map[string]interface{}{
+							"gt": 0,
 						},
 					},
 				},


### PR DESCRIPTION
This PR adds the ability to use the "sort", "_source" and "post_filter" attributes
in search requests, via the new methods `Sort`, `SourceIncludes` and `SourceExcludes`.

For example:
```
        esquery.Search().
            Query(...).
            Aggs(...).
            Sort("field_1", esquery.OrderAsc).
            Sort("field_2", esquery.OrderDesc).
            PostFilter(esquery.Range(field).Gt(0)).
            SourceIncludes("field_1", "field_2").
            SourceExcludes("field_3").
            Run(...)
```

