### PR TITLE
Add support for combined_fields query

### DIFF
--- a/query_combined_fields.go
+++ b/query_combined_fields.go
@@ -1,0 +1,86 @@
+package esquery
+
+import "github.com/fatih/structs"
+
+type CombinedFieldsQuery struct {
+	params combinedFieldsParams
+}
+
+// Map returns a map representation of the query; implementing the
+// Mappable interface.
+func (q *CombinedFieldsQuery) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"combined_fields": structs.Map(q.params),
+	}
+}
+
+type combinedFieldsParams struct {
+	Qry          interface{}    `structs:"query"`
+	Fields       []string       `structs:"fields"`
+	Boost        float32        `structs:"boost,omitempty"`
+	AutoGenerate *bool          `structs:"auto_generate_synonyms_phrase_query,omitempty"`
+	Op           MatchOperator  `structs:"operator,string,omitempty"`
+	MinMatch     string         `structs:"minimum_should_match,omitempty"`
+	ZeroTerms    ZeroTerms      `structs:"zero_terms_query,string,omitempty"`
+}
+
+// CombinedFields creates a new query of type "combined_fields"
+func CombinedFields(simpleQuery interface{}) *CombinedFieldsQuery {
+	return newCombinedFields(simpleQuery)
+}
+
+func newCombinedFields(simpleQuery interface{}) *CombinedFieldsQuery {
+	return &CombinedFieldsQuery{
+		params: combinedFieldsParams{
+			Qry: simpleQuery,
+		},
+	}
+}
+
+// Query sets the data to find in the query's field (it is the "query" component
+// of the query).
+func (q *CombinedFieldsQuery) Query(data interface{}) *CombinedFieldsQuery {
+	q.params.Qry = data
+	return q
+}
+
+// Fields sets the fields used in the query
+func (q *CombinedFieldsQuery) Fields(a ...string) *CombinedFieldsQuery {
+	q.params.Fields = append(q.params.Fields, a...)
+	return q
+}
+
+// AutoGenerateSynonymsPhraseQuery sets the "auto_generate_synonyms_phrase_query"
+// boolean.
+func (q *CombinedFieldsQuery) AutoGenerateSynonymsPhraseQuery(b bool) *CombinedFieldsQuery {
+	q.params.AutoGenerate = &b
+	return q
+}
+
+// Boost
+func (q *CombinedFieldsQuery) Boost(l float32) *CombinedFieldsQuery {
+	q.params.Boost = l
+	return q
+}
+
+// Operator sets the boolean logic used to interpret text in the query value.
+func (q *CombinedFieldsQuery) Operator(op MatchOperator) *CombinedFieldsQuery {
+	q.params.Op = op
+	return q
+}
+
+// MinimumShouldMatch sets the minimum number of clauses that must match for a
+// document to be returned.
+func (q *CombinedFieldsQuery) MinimumShouldMatch(s string) *CombinedFieldsQuery {
+	q.params.MinMatch = s
+	return q
+}
+
+// ZeroTermsQuery sets the "zero_terms_query" option to use. This indicates
+// whether no documents are returned if the analyzer removes all tokens, such as
+// when using a stop filter.
+func (q *CombinedFieldsQuery) ZeroTermsQuery(s ZeroTerms) *CombinedFieldsQuery {
+	q.params.ZeroTerms = s
+	return q
+}
+

--- a/query_combined_fields_test.go
+++ b/query_combined_fields_test.go
@@ -1,0 +1,43 @@
+package esquery
+
+import (
+	"testing"
+)
+
+func TestCombinedFields(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"simple combined_fields",
+			CombinedFields("value1").Fields("title"),
+			map[string]interface{}{
+				"combined_fields": map[string]interface{}{
+					"fields": []string{"title"},
+					"query":  "value1",
+				},
+			},
+		},
+		{
+			"combined_fields all params",
+			CombinedFields("original").
+				Query("test").
+				Fields("title", "body").
+				AutoGenerateSynonymsPhraseQuery(true).
+				Boost(6.4).
+				Operator(OperatorAnd).
+				MinimumShouldMatch("3<90%").
+				ZeroTermsQuery(ZeroTermsAll),
+			map[string]interface{}{
+				"combined_fields": map[string]interface{}{
+					"auto_generate_synonyms_phrase_query": true,
+					"boost":                               6.4,
+					"minimum_should_match":                "3<90%",
+					"operator":                            "AND",
+					"zero_terms_query":                    "all",
+					"query":                               "test",
+					"fields":                              []string{"title", "body"},
+				},
+			},
+		},
+	})
+}
+


### PR DESCRIPTION
This PR adds support for `combined_fields` that has been added in Elasticsearch 7.13.
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html