### PR TITLE
FEATURE: boost support added into match statement

### DIFF
--- a/query_match.go
+++ b/query_match.go
@@ -71,6 +71,7 @@ type matchParams struct {
 	MinMatch     string        `structs:"minimum_should_match,omitempty"`
 	ZeroTerms    ZeroTerms     `structs:"zero_terms_query,string,omitempty"`
 	Slp          uint16        `structs:"slop,omitempty"` // only relevant for match_phrase query
+	Boost        float32       `structs:"boost,omitempty"`
 }
 
 // Match creates a new query of type "match" with the provided field name.
@@ -200,6 +201,12 @@ func (q *MatchQuery) Slop(n uint16) *MatchQuery {
 func (q *MatchQuery) ZeroTermsQuery(s ZeroTerms) *MatchQuery {
 	q.params.ZeroTerms = s
 	return q
+}
+
+// Boost sets the boost value of the query.
+func (a *MatchQuery) Boost(b float32) *MatchQuery {
+	a.params.Boost = b
+	return a
 }
 
 // MatchOperator is an enumeration type representing supported values for a

--- a/query_match_test.go
+++ b/query_match_test.go
@@ -18,6 +18,18 @@ func TestMatch(t *testing.T) {
 			},
 		},
 		{
+			"simple match",
+			Match("title", "sample text").Boost(50),
+			map[string]interface{}{
+				"match": map[string]interface{}{
+					"title": map[string]interface{}{
+						"query": "sample text",
+						"boost": 50,
+					},
+				},
+			},
+		},
+		{
 			"match with more params",
 			Match("issue_number").Query(16).Transpositions(false).MaxExpansions(32).Operator(OperatorAnd),
 			map[string]interface{}{


### PR DESCRIPTION
### Motivation:
I was wondering, why there is no ability to pass boost in match statement, however it is 
available for bool and term statements. So I decided to add this behavior.

### Done:
In this pr I added support for boost inside match statement to omit overcomplicating
queries, I also opened related issue and added some examples there.

### Related links
See related issue by [following link](https://github.com/aquasecurity/esquery/issues/20).